### PR TITLE
implicitly convert error types

### DIFF
--- a/src/build_cmd.rs
+++ b/src/build_cmd.rs
@@ -297,7 +297,7 @@ pub fn handle_build_cmd(config: &Config) -> Result<(), Error> {
     let kernel_path = helios_artifact_path.join("kernel");
 
     if !helios_artifact_path.exists() {
-        create_dir(&helios_artifact_path).unwrap();
+        create_dir(&helios_artifact_path)?;
     }
 
     // copy the image out of the Cargo workspace

--- a/src/common.rs
+++ b/src/common.rs
@@ -6,6 +6,7 @@ use std::fmt;
 use std::fs::File;
 use std::io::prelude::*;
 use std::io::ErrorKind;
+use std::io;
 use std::process::Command;
 use toml::Value;
 
@@ -31,12 +32,20 @@ pub struct Config {
 
 pub enum Error {
     MetadataError(&'static str),
+    IO(String),
+}
+
+impl From<io::Error> for Error {
+    fn from(e: io::Error) -> Self {
+        Error::IO(format!("{}", e))
+    }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
+        match self {
             Error::MetadataError(msg) => write!(f, "metadata error: {}", msg),
+            Error::IO(msg) => write!(f, "IO error: {}", msg),
         }
     }
 }


### PR DESCRIPTION
This commit adds an implementation of `From<std::io::Error>` for our
error type allowing for implicit converions, thereby enabling the `?`
operator in applicable cases.