### PR TITLE
removes optional path positional argument

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ const USAGE: &str = "
 Build, manage and simulate Helios feL4 system images
 
 Usage:
-    cargo fel4 [options] [build | simulate | deploy | info] [<path>]
+    cargo fel4 [options] [build | simulate | deploy | info]
 
 Options:
     -h, --help                   Print this message
@@ -52,7 +52,6 @@ pub struct CliArgs {
     pub cmd_simulate: bool,
     pub cmd_deploy: bool,
     pub cmd_info: bool,
-    pub arg_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@ impl fmt::Display for Error {
         match self {
             Error::IO(msg) => write!(f, "[IO error] {}", msg),
             Error::ExitStatusError(msg) => write!(f, "[command error] {}", msg),
-            Error::ConfigError(msg) => write!(f, "[config error] {}\nncheck your project's toml files for invalid syntax", msg)
+            Error::ConfigError(msg) => write!(f, "[config error] {}\ncheck your project's toml files for invalid syntax", msg)
         }
     }
 }


### PR DESCRIPTION
Some validation:
1. vanilla Cargo can't do it.
1. `RUST_TARGET_PATH` can't be relative.  I can use `fs::canonicalize`
to resolve relative paths, but there are still assumptions made about
the path I'm on.  To get around this, I can set `root_dir` first, then
go through metadata collection. BUT
1. If I give an arbitrary path, e.g. `cargo fel4 build src/my-app`, it's
going to build things in `src/my-app/target`, which doesn't do me much
good from `.`.  That is, if `pwd == ~`, and I do `cargo fel4
build src/my-app`, what's the major advantage to that over `cd
src/my-app && cargo fel4 build` since me being at `~` or `~/src/my-app`
doesn't have any impact on the result.

Closes #26