### PR TITLE
use relocated `CMakeCache.txt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "package-config 0.0.1 (git+ssh://github.com/PolySync/fel4-dependencies.git?branch=devel)",
  "serde 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.47 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -152,6 +153,14 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "package-config"
+version = "0.0.1"
+source = "git+ssh://github.com/PolySync/fel4-dependencies.git?branch=devel#99a4295cfbb5d8871de396502930a4ef22c6b9e2"
+dependencies = [
+ "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -357,6 +366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
+"checksum package-config 0.0.1 (git+ssh://github.com/PolySync/fel4-dependencies.git?branch=devel)" = "<none>"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ cargo_metadata = "0.5"
 toml = "0.4"
 log = "0.4"
 colored = "1.6"
+package-config = {git = "ssh://github.com/PolySync/fel4-dependencies.git", branch = "devel"}

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -23,8 +23,8 @@ impl<'a, 'b, W: Write> Generator<'a, 'b, W> {
         self.write_line("#![feature(global_allocator)]")?;
         self.write_line("#![feature(alloc)]")?;
         self.write_line("")?;
-        self.write_line("extern crate sel4_entry;")?;
         self.write_line("extern crate sel4_sys;")?;
+        self.write_line("extern crate sel4_entry;")?;
         self.write_line("extern crate wee_alloc;")?;
         self.write_line("extern crate alloc;")?;
         self.write_line("")?;
@@ -40,9 +40,13 @@ impl<'a, 'b, W: Write> Generator<'a, 'b, W> {
         self.write_line("static ALLOCATOR: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;")?;
         self.write_line("")?;
         self.write_line("// include the seL4 kernel configurations")?;
-        self.write_line(
-            "include!(concat!(env!(\"OUT_DIR\"), \"/sel4_config.rs\"));",
-        )?;
+        self.write_line(&format!(
+            "include!(\"{}/sel4_config.rs\");",
+            self.config
+                .root_dir
+                .join(&self.config.fel4_metadata.artifact_path)
+                .display(),
+        ))?;
         self.write_line("")?;
         self.write_line("#[cfg(feature = \"KERNEL_DEBUG_BUILD\")]")?;
         self.write_line("#[inline(always)]")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate colored;
 #[macro_use]
 extern crate log;
 extern crate docopt;
+extern crate package_config;
 extern crate toml;
 
 use colored::Colorize;


### PR DESCRIPTION
With this commit `cargo-fel4` can use the `CMakeCache.txt` file that
libsel4-sys now places in `[fel4.artifact_path]`.