### PR TITLE
Config identifier unification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,6 +35,7 @@ dependencies = [
  "cmake_config 0.1.0",
  "colored 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "docopt 0.8.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -67,9 +68,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cmake_config"
 version = "0.1.0"
 dependencies = [
- "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 [dependencies]
 cmake_config = { version = "*", path = "cmake_config" }
 docopt = "0.8"
+heck = "0.3" # Can remove once we transition libsel4-sys' debug feature flag to non-shouty
 serde = "1.0"
 serde_derive = "1.0"
 cargo_metadata = "0.5"

--- a/cmake_config/Cargo.lock
+++ b/cmake_config/Cargo.lock
@@ -28,10 +28,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "cmake_config"
 version = "0.1.0"
 dependencies = [
- "heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "proptest 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -47,14 +47,6 @@ dependencies = [
 name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "heck"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "lazy_static"
@@ -85,6 +77,14 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "proc-macro2"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "proptest"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +102,14 @@ dependencies = [
 name = "quick-error"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quote"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rand"
@@ -139,6 +147,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "0.13.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,8 +171,8 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.2.1"
+name = "unicode-xid"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -201,21 +219,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
-"checksum heck 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ea04fa3ead4e05e51a7c806fc07271fdbde4e246a6c6d1efd52e72230b771b82"
 "checksum lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "cf186d1a8aa5f5bee5fd662bc9c1b949e0259e1bcc379d1f006847b0080c7417"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
+"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum proptest 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a3ff101e7a7be1104b3d71f194bc10a3fa338e89b3539444cfde6fdb3aae94a1"
 "checksum quick-error 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eda5fe9b71976e62bc81b781206aaa076401769b2143379d3eb2118388babac4"
+"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
 "checksum regex-syntax 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8e931c58b93d86f080c734bfd2bce7dd0079ae2331235818133c8be7f422e20e"
 "checksum regex-syntax 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8f1ac0f60d675cc6cf13a20ec076568254472551051ad5dd050364d70671bf6b"
+"checksum syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "61b8f1b737f929c6516ba46a3133fd6d5215ad8a62f66760f851f7048aebedfb"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
-"checksum unicode-segmentation 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "aa6024fc12ddfd1c6dbc14a80fa2324d4568849869b779f6bd37e5e4c03344d1"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/cmake_config/Cargo.toml
+++ b/cmake_config/Cargo.toml
@@ -5,9 +5,9 @@ publish = false
 description = "A parser for CMakeCache.txt files"
 
 [dependencies]
-heck = "0.3"
 lazy_static = "0.1"
 regex = "1"
+syn = "0.13"
 
 [dev-dependencies]
 proptest = "0.7"

--- a/cmake_config/tests/integration.rs
+++ b/cmake_config/tests/integration.rs
@@ -12,8 +12,8 @@ fn sanity_check_direct_from_string() {
 
     let v: Vec<SimpleFlag> = cmake_config::parse_raw(reader)
         .expect("Could not parse content")
-        .into_iter()
-        .map(|raw_flag| SimpleFlag::from(raw_flag))
+        .iter()
+        .map(SimpleFlag::from)
         .collect();
 
     assert_eq!(
@@ -71,9 +71,7 @@ fn sanity_check_tiny_file_parsing() {
         v
     );
 
-    let simplified: Vec<SimpleFlag> = v.into_iter()
-        .map(|raw_flag| SimpleFlag::from(raw_flag))
-        .collect();
+    let simplified: Vec<SimpleFlag> = v.iter().map(SimpleFlag::from).collect();
 
     assert_eq!(
         vec![

--- a/src/build_cmd.rs
+++ b/src/build_cmd.rs
@@ -6,9 +6,10 @@ use std::fs::File;
 use std::process::Command;
 
 use super::{run_cmd, Error};
+use cmake_codegen::{cache_to_interesting_flags, truthy_boolean_flags_as_rust_identifiers};
 use config::Config;
 use generator::Generator;
-use cmake_codegen::{cache_to_interesting_flags, truthy_boolean_flags_as_rust_identifiers};
+use heck::ShoutySnakeCase;
 
 pub fn handle_build_cmd(config: &Config) -> Result<(), Error> {
     let build_type = if config.cli_args.flag_release {
@@ -140,6 +141,10 @@ pub fn handle_build_cmd(config: &Config) -> Result<(), Error> {
         for feature in truthy_cmake_feature_flags {
             stage_2.arg("--cfg");
             stage_2.arg(format!("feature=\"{}\"", feature));
+
+            // TODO - remove once libsel4-sys updates its feature-flag casing for the temporary debug shim
+            stage_2.arg("--cfg");
+            stage_2.arg(format!("feature=\"{}\"", feature.to_shouty_snake_case()));
         }
     }
 

--- a/src/cmake_codegen.rs
+++ b/src/cmake_codegen.rs
@@ -72,8 +72,10 @@ pub fn truthy_boolean_flags_as_rust_identifiers<'a, I>(flags: I) -> Result<Vec<S
             SimpleFlag::Boolish(Key(_), false) => None,
             SimpleFlag::Boolish(Key(k), true) => Some(k)
         }) {
-        let rust_name = to_rust_const_identifier(active_cmake_bool_prop)?;
-        out.push(rust_name)
+        if !is_valid_rust_identifier(&active_cmake_bool_prop) {
+            return Err(CMakeCodegenError::GenerationError(RustCodeGenerationError::InvalidIdentifier(active_cmake_bool_prop)));
+        }
+        out.push(active_cmake_bool_prop)
     }
     Ok(out)
 }
@@ -92,6 +94,9 @@ impl From<CMakeCodegenError> for Error {
                     RustCodeGenerationError::InvalidIdentifier(s) => {
                         Error::ExitStatusError(format!("Invalid identifier interpreted from CMakeCache.txt: {}", s))
                     },
+                    RustCodeGenerationError::InvalidStringLiteral(s) => {
+                        Error::ExitStatusError(format!("Invalid Rust string literal generated from a value in CMakeCache.txt: {}", s))
+                    }
                 }
             },
             CMakeCodegenError::DuplicateIdentifiers(i) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ extern crate colored;
 extern crate log;
 extern crate cmake_config;
 extern crate docopt;
+extern crate heck;
 extern crate toml;
 
 use colored::Colorize;


### PR DESCRIPTION
Allows us to use the same identifiers in the following locations without conversion:
* fel4.toml
* CMakeCache.txt
* feature flags passed to the end-root-task build
* config constants generated as code in the root task.

Depends on https://github.com/PolySync/cargo-fel4/pull/35 landing.