### PR TITLE
Remove the command-line specification of target and platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ version = "0.1.0"
 dependencies = [
  "lazy_static 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -242,7 +242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -262,7 +262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.13.7"
+version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -371,7 +371,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.53 (registry+https://github.com/rust-lang/crates.io-index)" = "7149ef7af607b09e0e7df38b1fd74264f08a29a67f604d5cb09d3fbdb1e256bc"
 "checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"
 "checksum strsim 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d15c810519a91cf877e7e36e63fe068815c678181439f2f29e2562147c3694"
-"checksum syn 0.13.7 (registry+https://github.com/rust-lang/crates.io-index)" = "61b8f1b737f929c6516ba46a3133fd6d5215ad8a62f66760f851f7048aebedfb"
+"checksum syn 0.13.8 (registry+https://github.com/rust-lang/crates.io-index)" = "70f57ecb0ad755f810029917826394be7d5d3975e875028ff9d58ac71e640d80"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,8 +19,6 @@ Usage:
 Options:
     -h, --help                   Print this message
     --release                    Build artifacts in release mode, with optimizations
-    --target TRIPLE              Build for the target triple
-    --platform PLAT              Build for the target platform (used for deployment configuration)
     -v, --verbose                Use verbose output (-vv very verbose/build.rs output)
     -q, --quiet                  No output printed to stdout
 
@@ -46,8 +44,6 @@ pub struct CliArgs {
     pub flag_verbose: bool,
     pub flag_quiet: bool,
     pub flag_release: bool,
-    pub flag_target: String,
-    pub flag_platform: String,
     pub cmd_build: bool,
     pub cmd_simulate: bool,
     pub cmd_deploy: bool,
@@ -98,8 +94,8 @@ pub struct Fel4Metadata {
     pub artifact_path: PathBuf,
     #[serde(rename = "target-specs-path")]
     pub target_specs_path: PathBuf,
-    #[serde(rename = "default-target")]
-    pub default_target: String,
+    pub target: String,
+    pub platform: String,
 }
 
 #[derive(Debug, Clone)]
@@ -183,11 +179,7 @@ pub fn gather() -> Result<Config, Error> {
         fel4_table.clone().try_into()?
     };
 
-    let target = if cli_args.flag_target.is_empty() {
-        fel4_metadata.default_target.clone()
-    } else {
-        cli_args.flag_target.clone()
-    };
+    let target = fel4_metadata.target.clone();
     let arch = Arch::from_target_str(&target)?;
     let subcommand = SubCommand::from_cli_args(&cli_args)?;
 


### PR DESCRIPTION
In favor of trusting what's in the fel4.toml file.  This reduces the odds of incomplete overrides and removes the need to pipe down the override to the libsel4-sys build.