### PR TITLE
Include startup sequence assembly in generated root-task

### DIFF
--- a/src/asm/arm.s
+++ b/src/asm/arm.s
@@ -1,0 +1,34 @@
+/* Copyright (c) 2015 The Robigalia Project Developers
+ * Licensed under the Apache License, Version 2.0
+ * <LICENSE-APACHE or
+ * http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+ * license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+ * at your option. All files in the project carrying such
+ * notice may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+    .global _sel4_start
+    .global _start
+    .global _stack_bottom
+    .text
+
+_start:
+_sel4_start:
+    ldr sp, =_stack_top
+    /* r0, the first arg in the calling convention, is set to the bootinfo
+     * pointer on startup. */
+    bl __sel4_start_init_boot_info
+    /* zero argc, argv */
+    mov r0, #0
+    mov r1, #0
+    /* Now go to the "main" stub that rustc generates */
+    bl main
+
+.pool
+    .data
+    .align 4
+    .bss
+    .align  8
+_stack_bottom:
+    .space  65536
+_stack_top:

--- a/src/asm/x86.s
+++ b/src/asm/x86.s
@@ -1,0 +1,65 @@
+/* Copyright (c) 2015 The Robigalia Project Developers
+ * Licensed under the Apache License, Version 2.0
+ * <LICENSE-APACHE or
+ * http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+ * license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+ * at your option. All files in the project carrying such
+ * notice may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+    .global _sel4_start
+    .global _start
+    .global _stack_bottom
+    .text
+
+_start:
+_sel4_start:
+    leal    _stack_top, %esp
+    /* Setup segment selector for IPC buffer access. */
+    movw    $((7 << 3) | 3), %ax
+    movw    %ax, %fs
+    /* Setup the global "bootinfo" structure. */
+    pushl   %ebx
+    call    __sel4_start_init_boot_info
+    /* We drop another word off the stack pointer so that rustc's generated
+     * main can scrape the "argc" and "argv" off the stack.
+     * TODO: why is this necessary? Caller cleanup of above %ebx? */
+    addl    $4, %esp
+
+    /* Null terminate auxv */
+    pushl $0
+    pushl $0
+    /* Null terminate envp */
+    pushl $0
+    /* add at least one environment string (why?) */
+    leal environment_string, %eax
+    pushl %eax
+    /* Null terminate argv */
+    pushl $0
+    /* Give an argv[0] */
+    leal prog_name, %eax
+    pushl %eax
+    /* Give argc */
+    pushl $1
+    /* No atexit */
+    movl $0, %edx
+
+    /* Now go to the "main" stub that rustc generates */
+    call main
+
+    /* if main returns, die a loud and painful death. */
+    ud2
+
+    .data
+    .align 4
+
+environment_string:
+    .asciz "seL4=1"
+prog_name:
+    .asciz "rootserver"
+
+    .bss
+    .align  4096
+_stack_bottom:
+    .space  65536
+_stack_top:

--- a/src/asm/x86_64.s
+++ b/src/asm/x86_64.s
@@ -1,0 +1,61 @@
+/* Copyright (c) 2017 The Robigalia Project Developers
+ * Licensed under the Apache License, Version 2.0
+ * <LICENSE-APACHE or
+ * http://www.apache.org/licenses/LICENSE-2.0> or the MIT
+ * license <LICENSE-MIT or http://opensource.org/licenses/MIT>,
+ * at your option. All files in the project carrying such
+ * notice may not be copied, modified, or distributed except
+ * according to those terms.
+ */
+    .global _sel4_start
+    .global _start
+    .global _stack_bottom
+    .text
+
+_start:
+_sel4_start:
+    leaq    _stack_top, %rsp
+    /* Setup the global "bootinfo" structure. */
+    call    __sel4_start_init_boot_info
+
+    /* N.B. rsp MUST be aligned to a 16-byte boundary when main is called.
+     * Insert or remove padding here to make that happen.
+     */
+    pushq $0
+    /* Null terminate auxv */
+    pushq $0
+    pushq $0
+    /* Null terminate envp */
+    pushq $0
+    /* add at least one environment string (why?) */
+    leaq environment_string, %rax
+    pushq %rax
+    /* Null terminate argv */
+    pushq $0
+    /* Give an argv[0] (why?) */
+    leaq prog_name, %rax
+    pushq %rax
+    /* Give argc */
+    pushq $1
+    /* No atexit */
+    movq $0, %rdx
+
+    /* Now go to the "main" stub that rustc generates */
+    call main
+
+    /* if main returns, die a loud and painful death. */
+    ud2
+
+    .data
+    .align 4
+
+environment_string:
+    .asciz "seL4=1"
+prog_name:
+    .asciz "rootserver"
+
+    .bss
+    .align  4096
+_stack_bottom:
+    .space  65536
+_stack_top:

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ system images.
 Run `cargo fel4 build` from the top-level system directory.
 
 Resulting in:
-└── images
+└── artifacts
     └── feL4img
     └── kernel
 
@@ -110,19 +110,24 @@ pub struct Config {
     pub fel4_metadata: Fel4Metadata,
 }
 
+#[allow(non_camel_case_types)]
 #[derive(Debug, Clone)]
 pub enum Arch {
     X86,
+    X86_64,
     Arm,
 }
 
 impl Arch {
     fn from_target_str(target: &str) -> Result<Self, Error> {
         if target.contains("x86_64") {
-            return Ok(Arch::X86);
+            return Ok(Arch::X86_64);
         }
         if target.contains("arm") {
             return Ok(Arch::Arm);
+        }
+        if target.contains("i686") {
+            return Ok(Arch::X86)
         }
         Err(Error::ConfigError(format!(
             "could not derive architecture from target str: {}",


### PR DESCRIPTION
This stuff was lost back when we switched to generating the lang-items because it had been in the sel4-entry build script.