### PR TITLE
Add build profile delineation in artifact store

### DIFF
--- a/src/clean_cmd.rs
+++ b/src/clean_cmd.rs
@@ -1,0 +1,48 @@
+use log;
+use log::LevelFilter;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use super::{gather_config, run_cmd, Error};
+use config::{CleanCmd, Config, Fel4SubCmd};
+
+pub fn handle_clean_cmd(clean_cmd: &CleanCmd) -> Result<(), Error> {
+    if clean_cmd.verbose {
+        log::set_max_level(LevelFilter::Info);
+    } else {
+        log::set_max_level(LevelFilter::Error);
+    }
+
+    let config: Config = gather_config(&Fel4SubCmd::CleanCmd(clean_cmd.clone()))?;
+
+    let artifact_path = Path::new(&config.root_dir).join(config.fel4_config.artifact_path);
+
+    clean_cargo_build_cache(clean_cmd)?;
+
+    if artifact_path.exists() {
+        if clean_cmd.verbose {
+            info!("Removing {}", artifact_path.display());
+        }
+
+        fs::remove_dir_all(&artifact_path)?;
+    }
+
+    Ok(())
+}
+
+fn clean_cargo_build_cache(clean_cmd: &CleanCmd) -> Result<(), Error> {
+    let mut cmd = Command::new("cargo");
+
+    if clean_cmd.verbose {
+        cmd.arg("--verbose");
+    } else if clean_cmd.quiet {
+        cmd.arg("--quiet");
+    }
+
+    cmd.arg("clean");
+
+    run_cmd(&mut cmd)?;
+
+    Ok(())
+}

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -170,8 +170,11 @@ fn main() {
             Arch::Arm => {
                 writeln!(
                     self.writer,
-                    "    regs.pc = {}::run as seL4_Word;",
-                    self.config.pkg_module_name
+                    "    #[cfg(feature = \"test\")]
+    {{ regs.pc = {}::fel4_test::run as seL4_Word; }}
+    #[cfg(not(feature = \"test\"))]
+    {{ regs.pc = {}::run as seL4_Word; }}",
+                    self.config.pkg_module_name, self.config.pkg_module_name
                 )?;
                 writeln!(self.writer, "    regs.sp = stack_top as seL4_Word;")?;
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use std::io;
 use std::process::Command;
 
 mod build_cmd;
+mod clean_cmd;
 mod cmake_codegen;
 mod config;
 mod generator;
@@ -21,6 +22,7 @@ mod simulate_cmd;
 mod test_cmd;
 
 pub use build_cmd::handle_build_cmd;
+pub use clean_cmd::handle_clean_cmd;
 pub use config::{
     gather as gather_config, BuildCmd, CargoFel4Cli, Config, Fel4SubCmd, NewCmd, SimulateCmd,
     TestCmd, TestSubCmd,

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,5 +43,10 @@ fn main() {
                 error!("failed to run the test command\n{}", e)
             }
         }
+        Fel4SubCmd::CleanCmd(c) => {
+            if let Err(e) = cargo_fel4::handle_clean_cmd(&c) {
+                error!("failed to run the clean command\n{}", e)
+            }
+        }
     }
 }

--- a/src/new_cmd.rs
+++ b/src/new_cmd.rs
@@ -25,7 +25,7 @@ pub fn handle_new_cmd(subcmd: &NewCmd) -> Result<(), Error> {
 
     generate_fel4_project_files(subcmd)?;
 
-    generate_tests_source_files(Some(PathBuf::from(&subcmd.path)))?;
+    generate_tests_source_files(Some(subcmd.path.clone()))?;
 
     generate_target_specs(subcmd)?;
 


### PR DESCRIPTION
This commit introduces a feL4 build profile hierarchy for the output artifacts.

This allows us to have separate output artifact subdirectories
for each build profile we support, such that they won't interfere with each other.

We support building and simulating four different profiles:
- debug
    - `cargo fel4 build` and `cargo fel4 simulate`
- release
    - `cargo fel4 build --release` and `cargo fel4 simulate --release`
- test-debug
    - `cargo fel4 test build` and `cargo fel4 test simulate`
- test-release
    - `cargo fel4 test --release build` and `cargo fel4 test --release simulate`

When all build profiles have been built, the result looks like:

```
artifacts/
├── debug
│   ├── CMakeCache.txt
│   ├── feL4img
│   ├── kernel
│   └── simulate
├── release
│   ├── CMakeCache.txt
│   ├── feL4img
│   ├── kernel
│   └── simulate
└── test
    ├── debug
    │   ├── CMakeCache.txt
    │   ├── feL4img
    │   ├── kernel
    │   └── simulate
    └── release
        ├── CMakeCache.txt
        ├── feL4img
        ├── kernel
        └── simulate

```

This commit also introduces a `clean` subcommand to help cleanup feL4 produced artifacts.