### PR TITLE
Sort to-be RUSTFLAGS rust identifiers

### DIFF
--- a/src/cmake_codegen.rs
+++ b/src/cmake_codegen.rs
@@ -81,6 +81,10 @@ where
         }
         out.push(active_cmake_bool_prop.to_string())
     }
+
+    // sort the result so that we get a deterministic order
+    out.sort();
+
     Ok(out)
 }
 impl From<CMakeCodegenError> for Error {


### PR DESCRIPTION
Sort the vector of to-be rust identifiers, so that we get a
deterministic ordering.

Xargo will produce a unique hash for each configuration it sees, part of which
is constructed from the `RUSTFLAGS` environment variable.

It hashes the `RUSTFLAGS` on a per-token basis, so if the ordering of features changes, the hash
value also changes. This can cause unnecessary rebuilds of the sysroot packages.