### PR TITLE
Beginnings of the config reorganization, fix clean command

### DIFF
--- a/src/command_ext.rs
+++ b/src/command_ext.rs
@@ -1,0 +1,60 @@
+use super::Error;
+use config::LoudnessOpts;
+use std::ffi::OsStr;
+use std::process::Command;
+/// Extension methods for `Command` instances to supply common parameters or
+/// metadata
+pub trait CommandExt
+where
+    Self: Into<Command>,
+{
+    /// Add an argument if a predicate returns true, largely for easier chaining
+    fn arg_if<'c, P, S: AsRef<OsStr>>(&'c mut self, predicate: P, arg: S) -> &'c mut Self
+    where
+        P: FnOnce() -> bool;
+    /// Configures the presence of `--verbose` and `--quiet` flags
+    fn add_loudness_args<'c, 'f>(&'c mut self, loudness: &'f LoudnessOpts) -> &'c mut Self;
+
+    /// Execute a command with logging and status-code checking, discarding
+    /// most output
+    fn run_cmd(&mut self) -> Result<(), Error>;
+}
+
+impl CommandExt for Command {
+    fn arg_if<'c, P, S: AsRef<OsStr>>(&'c mut self, predicate: P, arg: S) -> &'c mut Self
+    where
+        P: FnOnce() -> bool,
+    {
+        if predicate() {
+            self.arg(arg);
+        }
+        self
+    }
+
+    fn add_loudness_args<'c, 'f>(&'c mut self, loudness: &LoudnessOpts) -> &mut Self {
+        self.arg_if(|| loudness.quiet, "--quiet")
+            .arg_if(|| loudness.verbose, "--verbose")
+    }
+
+    fn run_cmd(&mut self) -> Result<(), Error> {
+        info!("running: {:?}", self);
+        let status = match self.status() {
+            Ok(status) => status,
+            Err(e) => {
+                return Err(Error::ExitStatusError(format!(
+                    "failed to execute the command: {}",
+                    e
+                )));
+            }
+        };
+
+        if !status.success() {
+            return Err(Error::ExitStatusError(format!(
+                "command status returned: {}",
+                status
+            )));
+        }
+
+        Ok(())
+    }
+}

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -17,7 +17,12 @@ pub struct Generator<'a, 'b, 'c, W: Write + 'a> {
 }
 
 impl<'a, 'b, 'c, W: Write> Generator<'a, 'b, 'c, W> {
-    pub fn new(writer: &'a mut W, package_module_name: &'b str, arch: &'b Arch, flags: &'c [SimpleFlag]) -> Self
+    pub fn new(
+        writer: &'a mut W,
+        package_module_name: &'b str,
+        arch: &'b Arch,
+        flags: &'c [SimpleFlag],
+    ) -> Self
     where
         W: Write,
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,11 @@ extern crate structopt;
 use colored::Colorize;
 use std::fmt;
 use std::io;
-use std::process::Command;
 
 mod build_cmd;
 mod clean_cmd;
 mod cmake_codegen;
+mod command_ext;
 mod config;
 mod generator;
 mod new_cmd;
@@ -24,8 +24,8 @@ mod test_cmd;
 pub use build_cmd::handle_build_cmd;
 pub use clean_cmd::handle_clean_cmd;
 pub use config::{
-    gather as gather_config, BuildCmd, CargoFel4Cli, Config, Fel4SubCmd, NewCmd, SimulateCmd,
-    TestCmd, TestSubCmd,
+    gather as gather_config, BuildCmd, CargoFel4Cli, CleanCmd, Config, Fel4SubCmd, LoudnessOpts,
+    NewCmd, SimulateCmd, TestCmd, TestSubCmd,
 };
 pub use new_cmd::handle_new_cmd;
 pub use simulate_cmd::handle_simulate_cmd;
@@ -89,26 +89,4 @@ impl log::Log for Logger {
     }
 
     fn flush(&self) {}
-}
-
-pub fn run_cmd(cmd: &mut Command) -> Result<(), Error> {
-    info!("running: {:?}", cmd);
-    let status = match cmd.status() {
-        Ok(status) => status,
-        Err(e) => {
-            return Err(Error::ExitStatusError(format!(
-                "failed to execute the command: {}",
-                e
-            )));
-        }
-    };
-
-    if !status.success() {
-        return Err(Error::ExitStatusError(format!(
-            "command status returned: {}",
-            status
-        )));
-    }
-
-    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ extern crate structopt;
 extern crate log;
 extern crate cargo_fel4;
 
-use cargo_fel4::{CargoFel4Cli, Fel4SubCmd, Logger};
+use cargo_fel4::{CargoFel4Cli, Fel4SubCmd, Logger, LoudnessOpts};
 use log::LevelFilter;
 use structopt::StructOpt;
 
@@ -24,29 +24,42 @@ fn main() {
 
     match subcmd {
         Fel4SubCmd::BuildCmd(c) => {
+            set_logging_level(&c.loudness);
             if let Err(e) = cargo_fel4::handle_build_cmd(&c) {
                 error!("failed to run the build command\n{}", e)
             }
         }
         Fel4SubCmd::SimulateCmd(c) => {
+            set_logging_level(&c.loudness);
             if let Err(e) = cargo_fel4::handle_simulate_cmd(&c) {
                 error!("failed to run the simulation command\n{}", e)
             }
         }
         Fel4SubCmd::NewCmd(c) => {
+            set_logging_level(&c.loudness);
             if let Err(e) = cargo_fel4::handle_new_cmd(&c) {
                 error!("failed to run the new command\n{}", e)
             }
         }
         Fel4SubCmd::TestCmd(c) => {
+            set_logging_level(&c.loudness);
             if let Err(e) = cargo_fel4::handle_test_cmd(&c) {
                 error!("failed to run the test command\n{}", e)
             }
         }
         Fel4SubCmd::CleanCmd(c) => {
+            set_logging_level(&c.loudness);
             if let Err(e) = cargo_fel4::handle_clean_cmd(&c) {
                 error!("failed to run the clean command\n{}", e)
             }
         }
     }
+}
+
+fn set_logging_level(LoudnessOpts { verbose, quiet }: &LoudnessOpts) {
+    log::set_max_level(match (verbose, quiet) {
+        (true, _) => LevelFilter::Info,
+        (false, true) => LevelFilter::Off,
+        _ => LevelFilter::Error,
+    });
 }

--- a/src/simulate_cmd.rs
+++ b/src/simulate_cmd.rs
@@ -1,18 +1,11 @@
-use log;
-use log::LevelFilter;
 use std::path::Path;
 use std::process::Command;
 
-use super::{gather_config, run_cmd, Error};
+use super::{gather_config, Error};
+use command_ext::CommandExt;
 use config::{Config, Fel4SubCmd, SimulateCmd};
 
 pub fn handle_simulate_cmd(subcmd: &SimulateCmd) -> Result<(), Error> {
-    if subcmd.verbose {
-        log::set_max_level(LevelFilter::Info);
-    } else {
-        log::set_max_level(LevelFilter::Error);
-    }
-
     let config: Config = gather_config(&Fel4SubCmd::SimulateCmd(subcmd.clone()))?;
 
     let artifact_profile_subdir = if let Some(p) = config.build_profile {
@@ -37,7 +30,7 @@ pub fn handle_simulate_cmd(subcmd: &SimulateCmd) -> Result<(), Error> {
         )));
     }
 
-    run_cmd(&mut Command::new(&sim_script_path).current_dir(&artifact_path.parent().unwrap()))?;
-
-    Ok(())
+    Command::new(&sim_script_path)
+        .current_dir(&artifact_path.parent().unwrap())
+        .run_cmd()
 }

--- a/src/test_cmd.rs
+++ b/src/test_cmd.rs
@@ -1,22 +1,19 @@
 use super::{handle_build_cmd, handle_simulate_cmd, Error};
 use config::{BuildCmd, SimulateCmd, TestCmd, TestSubCmd};
-use log;
-use log::LevelFilter;
 use new_cmd::generate_tests_source_files;
 
 pub fn handle_test_cmd(test_cmd: &TestCmd) -> Result<(), Error> {
-    if test_cmd.verbose {
-        log::set_max_level(LevelFilter::Info);
-    } else {
-        log::set_max_level(LevelFilter::Error);
-    }
-
     match test_cmd.subcmd {
         TestSubCmd::Build => {
             generate_tests_source_files(test_cmd.cargo_manifest_path.parent())?;
             run_test_build(test_cmd)?;
         }
         TestSubCmd::Simulate => run_test_simulation(test_cmd)?,
+        _ => {
+            generate_tests_source_files(test_cmd.cargo_manifest_path.parent())?;
+            run_test_build(test_cmd)?;
+            run_test_simulation(test_cmd)?
+        }
     };
 
     Ok(())
@@ -24,8 +21,7 @@ pub fn handle_test_cmd(test_cmd: &TestCmd) -> Result<(), Error> {
 
 fn run_test_build(test_cmd: &TestCmd) -> Result<(), Error> {
     let build_cmd = BuildCmd {
-        verbose: test_cmd.verbose,
-        quiet: test_cmd.quiet,
+        loudness: test_cmd.loudness.clone(),
         release: test_cmd.release,
         tests: true,
         cargo_manifest_path: test_cmd.cargo_manifest_path.clone(),
@@ -38,8 +34,7 @@ fn run_test_build(test_cmd: &TestCmd) -> Result<(), Error> {
 
 fn run_test_simulation(test_cmd: &TestCmd) -> Result<(), Error> {
     let sim_cmd = SimulateCmd {
-        verbose: test_cmd.verbose,
-        quiet: test_cmd.quiet,
+        loudness: test_cmd.loudness.clone(),
         release: test_cmd.release,
         tests: true,
         cargo_manifest_path: test_cmd.cargo_manifest_path.clone(),

--- a/templates/fel4_test.rs
+++ b/templates/fel4_test.rs
@@ -60,9 +60,9 @@ fn test_message_info_predictability(
         &(0u32..0xfffff, 0u32..0x7, 0u32..0x3, 0u32..0x7f),
         |&input| {
             let (label, caps, extra, length) = input;
+            let (label, caps, extra, length) = (label as seL4_Word, caps as seL4_Word, extra as seL4_Word, length as seL4_Word);
             let out = unsafe {
                 let msg = seL4_MessageInfo_new(label, caps, extra, length);
-                let (label, caps, extra, length) = (label as seL4_Word, caps as seL4_Word, extra as seL4_Word, length as seL4_Word);
                 let ptr = &msg as *const seL4_MessageInfo_t as *mut seL4_MessageInfo_t;
                 (
                     seL4_MessageInfo_ptr_get_label(ptr),
@@ -90,9 +90,9 @@ fn test_cap_rights_predictability(
 ) -> Result<(), TestError<(u32, u32, u32)>> {
     runner.run(&(0u32..2, 0u32..2, 0u32..2), |&input| {
         let (grant, read, write) = input;
+        let (grant, read, write) = (grant as seL4_Word, read as seL4_Word, write as seL4_Word);
         let out = unsafe {
             let msg = seL4_CapRights_new(grant, read, write);
-            let (grant, read, write) = (grant as seL4_Word, read as seL4_Word, write as seL4_Word);
             let ptr = &msg as *const seL4_CapRights_t as *mut seL4_CapRights_t;
             (
                 seL4_CapRights_ptr_get_capAllowRead(ptr),


### PR DESCRIPTION
* Use a shared command-arg structure, LoudnessOpts, for repeated verbosity arguments
* Factor out the reusable bits of `std::process::Command` improvements from build_cmd.rs and lib.rs and into a shareable location as an extension trait to reduce duplicate code handling of common patterns.
* Remove the use of `gather_config` from clean_cmd.rs as the beginnings of the end of its insidious reign.  Use more targeted configuration-determination methods instead of the mega-`Config` object.
* Add execution of the `cargo fel4 clean` command to our basic integration suite
* Move log-level setting to `main.rs` as part of deduplication of effort.
* Fix a code placement error that caused the intentional shadow-casting for word size to occur too late in the test scope.